### PR TITLE
You missed "," at setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
         "PyYAML>=5.1.2",
         "gql>=v3.0.0a1",
         "pyreadline >= 2.1;platform_system=='Windows'",
-        "flask"
+        "flask",
         "googletrans",
         "SpeechRecognition",
         "PyAudio",


### PR DESCRIPTION
Fix for 
```(base) C:\Projects\GPT3-Demo\ai-dungeon-cli>pip install -e .
Obtaining file:///C:/Projects/GPT3-Demo/ai-dungeon-cli
Requirement already satisfied: requests>=2.23.0 in c:\conda\lib\site-packages (from ai-dungeon-cli==0.4.4) (2.24.0)
Requirement already satisfied: PyYAML>=5.1.2 in c:\conda\lib\site-packages (from ai-dungeon-cli==0.4.4) (5.3.1)
Requirement already satisfied: gql>=v3.0.0a1 in c:\conda\lib\site-packages (from ai-dungeon-cli==0.4.4) (3.0.0a1)
ERROR: Could not find a version that satisfies the requirement flaskgoogletrans (from ai-dungeon-cli==0.4.4) (from versions: none)
ERROR: No matching distribution found for flaskgoogletrans (from ai-dungeon-cli==0.4.4)
```